### PR TITLE
Supporting any s3 uri (not just s3 bucket) and '--download-cache'

### DIFF
--- a/mkwheelhouse.py
+++ b/mkwheelhouse.py
@@ -93,7 +93,7 @@ class Bucket:
         return doc.getvalue()
 
 
-def build_wheels(packages, index_url, download_cache):
+def build_wheels(packages, index_url, cache_dir):
     packages = packages or []
     temp_dir = tempfile.mkdtemp(prefix='mkwheelhouse-')
     args = [
@@ -101,8 +101,8 @@ def build_wheels(packages, index_url, download_cache):
         '--wheel-dir', temp_dir,
         '--find-links', index_url
     ]
-    if download_cache:
-        args += ['--download-cache', download_cache]
+    if cache_dir:
+        args += ['--cache-dir', cache_dir]
     args += packages
     subprocess.check_call(args)
     return temp_dir
@@ -112,7 +112,7 @@ def main():
     parser = argparse.ArgumentParser(
         description='Generate and upload wheels to an Amazon S3 wheelhouse')
     parser.add_argument('bucket')
-    parser.add_argument('--download-cache')
+    parser.add_argument('--cache-dir')
     parser.add_argument('package', nargs='+')
 
     args = parser.parse_args()
@@ -120,7 +120,7 @@ def main():
     bucket = Bucket(args.bucket)
     index_url = bucket.resource_url('index.html')
 
-    build_dir = build_wheels(args.package, index_url, args.download_cache)
+    build_dir = build_wheels(args.package, index_url, args.cache_dir)
     bucket.sync(build_dir)
     bucket.put(bucket.index(), key='index.html')
 

--- a/mkwheelhouse.py
+++ b/mkwheelhouse.py
@@ -11,9 +11,12 @@ import tempfile
 import botocore.session
 import yattag
 
+
 class Bucket:
-    def __init__(self, name):
-        self.name = name
+    def __init__(self, uri):
+        self.uri = uri.strip('/')
+        split_uri = self.uri.split('/')
+        self.name, self.path = split_uri[0], '/'.join(split_uri[1:])
         self.s3_service = botocore.session.get_session().get_service('s3')
 
     def region(self):
@@ -21,7 +24,7 @@ class Bucket:
             default_endpoint = self.s3_service.get_endpoint()
             op = self.s3_service.get_operation('GetBucketLocation')
             http_response, response_data = op.call(default_endpoint,
-                                                   bucket=self.name)
+                                                   bucket=self.uri)
             self._region = response_data['LocationConstraint']
         return self._region
 
@@ -29,10 +32,10 @@ class Bucket:
         return self.s3_service.get_endpoint(self.region())
 
     def remote_url(self):
-        return 's3://{}'.format(self.name)
+        return 's3://{}'.format(self.uri)
 
     def resource_url(self, resource):
-        return os.path.join(self.endpoint().host, self.name, resource)
+        return os.path.join(self.endpoint().host, self.uri, resource)
 
     def sync(self, local_dir):
         return subprocess.check_call([
@@ -43,7 +46,7 @@ class Bucket:
     def put(self, body, key):
         args = [
             'aws', 's3api', 'put-object',
-            '--bucket', self.name,
+            '--bucket', self.uri,
             '--region', self.region(),
             '--key', key
         ]
@@ -61,14 +64,20 @@ class Bucket:
     def wheels(self):
         op = self.s3_service.get_operation('ListObjects')
         http_response, response_data = op.call(self.endpoint(), bucket=self.name)
-
         keys = [obj['Key'] for obj in response_data['Contents']]
-        keys = [key for key in keys if key.endswith('.whl')]
 
         wheels = []
         for key in keys:
-            url = self.resource_url(key)
-            wheels.append((key, url))
+            if not key.endswith('.whl'):
+                continue
+            key_split = key.split('/')
+            if not self.path and len(key_split) > 1:
+                continue
+            elif self.path != '/'.join(key_split[:-1]):
+                continue
+            file = key_split[-1]
+            url = self.resource_url(file)
+            wheels.append((file, url))
 
         return wheels
 
@@ -82,6 +91,7 @@ class Bucket:
 
         return doc.getvalue()
 
+
 def build_wheels(packages, index_url):
     packages = packages or []
     temp_dir = tempfile.mkdtemp(prefix='mkwheelhouse-')
@@ -93,6 +103,7 @@ def build_wheels(packages, index_url):
     args += packages
     subprocess.check_call(args)
     return temp_dir
+
 
 def main():
     parser = argparse.ArgumentParser(
@@ -110,6 +121,7 @@ def main():
     bucket.put(bucket.index(), key='index.html')
 
     print('Index written to:', index_url)
+
 
 if __name__ == '__main__':
     main()

--- a/mkwheelhouse.py
+++ b/mkwheelhouse.py
@@ -63,7 +63,8 @@ class Bucket:
 
     def wheels(self):
         op = self.s3_service.get_operation('ListObjects')
-        http_response, response_data = op.call(self.endpoint(), bucket=self.name)
+        http_response, response_data = op.call(self.endpoint(),
+                                               bucket=self.name)
         keys = [obj['Key'] for obj in response_data['Contents']]
 
         wheels = []
@@ -92,7 +93,7 @@ class Bucket:
         return doc.getvalue()
 
 
-def build_wheels(packages, index_url):
+def build_wheels(packages, index_url, download_cache):
     packages = packages or []
     temp_dir = tempfile.mkdtemp(prefix='mkwheelhouse-')
     args = [
@@ -100,6 +101,8 @@ def build_wheels(packages, index_url):
         '--wheel-dir', temp_dir,
         '--find-links', index_url
     ]
+    if download_cache:
+        args += ['--download-cache', download_cache]
     args += packages
     subprocess.check_call(args)
     return temp_dir
@@ -109,6 +112,7 @@ def main():
     parser = argparse.ArgumentParser(
         description='Generate and upload wheels to an Amazon S3 wheelhouse')
     parser.add_argument('bucket')
+    parser.add_argument('--download-cache')
     parser.add_argument('package', nargs='+')
 
     args = parser.parse_args()
@@ -116,7 +120,7 @@ def main():
     bucket = Bucket(args.bucket)
     index_url = bucket.resource_url('index.html')
 
-    build_dir = build_wheels(args.package, index_url)
+    build_dir = build_wheels(args.package, index_url, args.download_cache)
     bucket.sync(build_dir)
     bucket.put(bucket.index(), key='index.html')
 


### PR DESCRIPTION
Supporting any s3 uri not just s3 bucket
Use cases:
- Having wheelhouse in a different bucket
- Having multiple wheelhouses for different builds

Added support for --download-cache
`mkwheelhouse <s3_uri>--download-cache some/dir <pacakges>`
Note that pip 6 deprecated '--download-cache', but pip wheel still supports it.
