### PR TITLE
Fix blank folder creation and index in s3

### DIFF
--- a/mkwheelhouse.py
+++ b/mkwheelhouse.py
@@ -25,7 +25,7 @@ class Bucket(object):
             url = '//' + url
         url = urlparse(url)
         self.name = url.netloc
-        self.prefix = url.path
+        self.prefix = re.sub('^/', '', url.path)
         # Boto currently can't handle names with dots unless the region
         # is specified explicitly.
         # See: https://github.com/boto/boto/issues/2836
@@ -73,7 +73,7 @@ class Bucket(object):
     def sync(self, local_dir):
         return subprocess.check_call([
             'aws', 's3', 'sync',
-            local_dir, 's3://{0}{1}'.format(self.name, self.prefix),
+            local_dir, 's3://{0}/{1}'.format(self.name, self.prefix),
             '--region', self.region])
 
     def put(self, body, key):

--- a/mkwheelhouse.py
+++ b/mkwheelhouse.py
@@ -73,7 +73,7 @@ class Bucket(object):
     def sync(self, local_dir):
         return subprocess.check_call([
             'aws', 's3', 'sync',
-            local_dir, 's3://{0}/{1}'.format(self.name, self.prefix),
+            local_dir, 's3://{0}{1}'.format(self.name, self.prefix),
             '--region', self.region])
 
     def put(self, body, key):


### PR DESCRIPTION
When mkwheelhouse is configured to sync to a subfolder in a s3 bucket, the prefix value generated by   `urlparse.path` returns the path with a leading slash. This is not a valid s3 prefix (they cannot contain slashes) and the string formatting in `sync` task creates the URI with two slashes resulting a blank folder being created in the root of the bucket.
